### PR TITLE
[AT][Start][Weather][CurrentWeather][h2] testH2TagText_WhenSearchCityCountry()<AnastasiaUsGo>

### DIFF
--- a/src/test/java/AnastasiaUsGoTest.java
+++ b/src/test/java/AnastasiaUsGoTest.java
@@ -1,0 +1,72 @@
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import runner.BaseTest;
+
+public class AnastasiaUsGoTest extends BaseTest {
+    final static String BASE_URL = "https://openweathermap.org/";
+
+    final static By H2_CITY_COUNTRY_HEADER = By.xpath("//div[@id='weather-widget']//h2");
+    final static By SEARCH_CITY_FIELD = By.
+            xpath("//div[@id='weather-widget']//input[@placeholder='Search city']");
+    final static By SEARCH_BUTTON = By.xpath("//div[@id='weather-widget']//button[@type='submit']");
+    final static By SEARCH_DROPDOWN_MENU= By.className("search-dropdown-menu");
+    final static By PARIS_FR_CHOICE_IN_DROPDOWN_MENU = By.
+            xpath("//ul[@class='search-dropdown-menu']/li/span[text()='Paris, FR ']");
+
+    private void openBaseURL() {
+        getDriver().get(BASE_URL);
+    }
+
+    private void waitForGrayFrameDisappeared() {
+        getWait20().until(ExpectedConditions.invisibilityOfElementLocated(
+                By.className("owm-loader-container")));
+    }
+
+    private String getText(By by, WebDriver driver) {
+        return driver.findElement(by).getText();
+    }
+
+    private void click(By by, WebDriverWait wait) {
+        wait.until(ExpectedConditions.visibilityOfElementLocated(by));
+        wait.until(ExpectedConditions.elementToBeClickable(by)).click();
+    }
+
+    private void input(String text, By by, WebDriver driver) {
+        driver.findElement(by).sendKeys(text);
+    }
+
+    private void waitElementToBeVisible(By by, WebDriverWait wait) {
+        wait.until(ExpectedConditions.visibilityOfElementLocated(by));
+    }
+
+    private void waitTextToBeChanged(By by, String text, WebDriver driver, WebDriverWait wait) {
+        wait.until(ExpectedConditions.not(ExpectedConditions.
+                textToBePresentInElement(driver.findElement(by), text)));
+    }
+
+    @Test
+    public void testH2TagText_WhenSearchCityCountry() {
+        String cityName = "Paris";
+        String expectedResult = "Paris, FR";
+
+        openBaseURL();
+        waitForGrayFrameDisappeared();
+
+        String oldH2Header = getText(H2_CITY_COUNTRY_HEADER, getDriver());
+
+        click(SEARCH_CITY_FIELD, getWait5());
+        input(cityName, SEARCH_CITY_FIELD, getDriver());
+        click(SEARCH_BUTTON, getWait10());
+        waitElementToBeVisible(SEARCH_DROPDOWN_MENU, getWait10());
+        click(PARIS_FR_CHOICE_IN_DROPDOWN_MENU, getWait10());
+        waitTextToBeChanged(H2_CITY_COUNTRY_HEADER, oldH2Header, getDriver(), getWait10());
+
+        String actualResult = getText(H2_CITY_COUNTRY_HEADER, getDriver());
+
+        Assert.assertEquals(actualResult, expectedResult);
+    }
+}


### PR DESCRIPTION
testH2TagText_WhenSearchCityCountry() added

[US] - https://trello.com/c/tfxcHuwX/59-usfunctionalstartweathersearchcity-search-city-function
[TC] - https://trello.com/c/LA6W7Zp4/110-tc-verify-that-city-country-names-changed-in-current-weather-block-when-user-search-specific-city-country-in-search-bar-anastasi
[AT] - https://trello.com/c/aen4TdsL/140-atstartweathercurrentweatherh2-testh2tagtextwhensearchcitycountryanastasiausgo